### PR TITLE
Update PackageReference for System.Management to latest (5.0.0). (#1805)

### DIFF
--- a/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
+++ b/src/BenchmarkDotNet.Annotations/Jobs/RuntimeMoniker.cs
@@ -88,7 +88,12 @@ namespace BenchmarkDotNet.Jobs
         /// <summary>
         /// .NET 6.0
         /// </summary>
-        Net60, // it's after NetCoreApp50 and Net50 in the enum definition because the value of enumeration is used for framework version comparison using > < operators
+        Net60,
+
+        /// <summary>
+        /// .NET 7.0
+        /// </summary>
+        Net70,
 
         /// <summary>
         /// CoreRT compiled as netcoreapp2.0
@@ -126,6 +131,11 @@ namespace BenchmarkDotNet.Jobs
         CoreRt60,
 
         /// <summary>
+        /// CoreRT compiled as net7.0
+        /// </summary>
+        CoreRt70,
+
+        /// <summary>
         /// WebAssembly with default .Net version
         /// </summary>
         Wasm,
@@ -139,6 +149,11 @@ namespace BenchmarkDotNet.Jobs
         /// WebAssembly with .net6.0
         /// </summary>
         WasmNet60,
+
+        /// <summary>
+        /// WebAssembly with .net7.0
+        /// </summary>
+        WasmNet70,
 
         /// <summary>
         /// Mono with the Ahead of Time LLVM Compiler backend

--- a/src/BenchmarkDotNet/BenchmarkDotNet.csproj
+++ b/src/BenchmarkDotNet/BenchmarkDotNet.csproj
@@ -18,9 +18,9 @@
     <PackageReference Include="Iced" Version="1.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.126102" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
-    <PackageReference Include="System.Management" Version="4.5.0" />
+    <PackageReference Include="System.Management" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -352,6 +352,7 @@ namespace BenchmarkDotNet.ConsoleArguments
 #pragma warning restore CS0618 // Type or member is obsolete
                 case RuntimeMoniker.Net50:
                 case RuntimeMoniker.Net60:
+                case RuntimeMoniker.Net70:
                     return baseJob
                         .WithRuntime(runtimeMoniker.GetRuntime())
                         .WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings(runtimeId, null, runtimeId, options.CliPath?.FullName, options.RestorePath?.FullName, timeOut)));
@@ -364,6 +365,7 @@ namespace BenchmarkDotNet.ConsoleArguments
                 case RuntimeMoniker.CoreRt31:
                 case RuntimeMoniker.CoreRt50:
                 case RuntimeMoniker.CoreRt60:
+                case RuntimeMoniker.CoreRt70:
                     var builder = CoreRtToolchain.CreateBuilder();
 
                     if (options.CliPath != null)
@@ -391,6 +393,8 @@ namespace BenchmarkDotNet.ConsoleArguments
                     return MakeWasmJob(baseJob, options, timeOut, "net5.0");
                 case RuntimeMoniker.WasmNet60:
                     return MakeWasmJob(baseJob, options, timeOut, "net6.0");
+                case RuntimeMoniker.WasmNet70:
+                    return MakeWasmJob(baseJob, options, timeOut, "net7.0");
                 case RuntimeMoniker.MonoAOTLLVM:
                     var monoAotLLVMRuntime = new MonoAotLLVMRuntime(aotCompilerPath: options.AOTCompilerPath);
 

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRtRuntime.cs
@@ -34,7 +34,11 @@ namespace BenchmarkDotNet.Environments
         /// <summary>
         /// CoreRT compiled as net6.0
         /// </summary>
-        public static readonly CoreRtRuntime CoreRt60 = new CoreRtRuntime(RuntimeMoniker.CoreRt50, "net6.0", "CoreRT 6.0");
+        public static readonly CoreRtRuntime CoreRt60 = new CoreRtRuntime(RuntimeMoniker.CoreRt60, "net6.0", "CoreRT 6.0");
+        /// <summary>
+        /// CoreRT compiled as net7.0
+        /// </summary>
+        public static readonly CoreRtRuntime CoreRt70 = new CoreRtRuntime(RuntimeMoniker.CoreRt70, "net7.0", "CoreRT 7.0");
 
         private CoreRtRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)
@@ -62,6 +66,7 @@ namespace BenchmarkDotNet.Environments
                 case Version v when v.Major == 3 && v.Minor == 1: return CoreRt31;
                 case Version v when v.Major == 5 && v.Minor == 0: return CoreRt50;
                 case Version v when v.Major == 6 && v.Minor == 0: return CoreRt60;
+                case Version v when v.Major == 7 && v.Minor == 0: return CoreRt70;
                 default:
                     return new CoreRtRuntime(RuntimeMoniker.NotRecognized, $"net{version.Major}.{version.Minor}", $"CoreRT {version.Major}.{version.Minor}");
             }

--- a/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
+++ b/src/BenchmarkDotNet/Environments/Runtimes/CoreRuntime.cs
@@ -18,6 +18,7 @@ namespace BenchmarkDotNet.Environments
         public static readonly CoreRuntime Core31 = new CoreRuntime(RuntimeMoniker.NetCoreApp31, "netcoreapp3.1", ".NET Core 3.1");
         public static readonly CoreRuntime Core50 = new CoreRuntime(RuntimeMoniker.Net50, "net5.0", ".NET 5.0");
         public static readonly CoreRuntime Core60 = new CoreRuntime(RuntimeMoniker.Net60, "net6.0", ".NET 6.0");
+        public static readonly CoreRuntime Core70 = new CoreRuntime(RuntimeMoniker.Net70, "net7.0", ".NET 7.0");
 
         private CoreRuntime(RuntimeMoniker runtimeMoniker, string msBuildMoniker, string displayName)
             : base(runtimeMoniker, msBuildMoniker, displayName)
@@ -66,6 +67,7 @@ namespace BenchmarkDotNet.Environments
                 case Version v when v.Major == 3 && v.Minor == 1: return Core31;
                 case Version v when v.Major == 5 && v.Minor == 0: return GetPlatformSpecific(Core50);
                 case Version v when v.Major == 6 && v.Minor == 0: return GetPlatformSpecific(Core60);
+                case Version v when v.Major == 7 && v.Minor == 0: return GetPlatformSpecific(Core70);
                 default:
                     return CreateForNewVersion($"net{version.Major}.{version.Minor}", $".NET {version.Major}.{version.Minor}");
             }

--- a/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
+++ b/src/BenchmarkDotNet/Extensions/RuntimeMonikerExtensions.cs
@@ -39,6 +39,8 @@ namespace BenchmarkDotNet.Extensions
                     return CoreRuntime.Core50;
                 case RuntimeMoniker.Net60:
                     return CoreRuntime.Core60;
+                case RuntimeMoniker.Net70:
+                    return CoreRuntime.Core70;
                 case RuntimeMoniker.Mono:
                     return MonoRuntime.Default;
                 case RuntimeMoniker.CoreRt20:
@@ -55,6 +57,8 @@ namespace BenchmarkDotNet.Extensions
                     return CoreRtRuntime.CoreRt50;
                 case RuntimeMoniker.CoreRt60:
                     return CoreRtRuntime.CoreRt60;
+                case RuntimeMoniker.CoreRt70:
+                    return CoreRtRuntime.CoreRt70;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "Runtime Moniker not supported");
             }

--- a/src/BenchmarkDotNet/Helpers/FolderNameHelper.cs
+++ b/src/BenchmarkDotNet/Helpers/FolderNameHelper.cs
@@ -49,9 +49,10 @@ namespace BenchmarkDotNet.Helpers
             foreach (char invalidPathChar in Path.GetInvalidFileNameChars())
                 builder.Replace(invalidPathChar, '_');
 
-            // > and < are valid on Unix, but not on Windows. File names should be consistent across all OSes #981
+            // >, <, and : are valid on Unix, but not on Windows. File names should be consistent across all OSes #981
             builder.Replace('<', '_');
             builder.Replace('>', '_');
+            builder.Replace(':', '_');
 
             return builder.ToString();
         }

--- a/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
+++ b/src/BenchmarkDotNet/Parameters/SmartParamBuilder.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Parameters
             {
                 // the user provided object[] for a benchmark accepting a single argument
                 if (parameterDefinitions.Length == 1 && array.Length == 1
-                    && array[0].GetType() == benchmark.GetParameters().FirstOrDefault()?.ParameterType) // the benchmark that accepts an object[] as argument
+                    && array[0]?.GetType() == benchmark.GetParameters().FirstOrDefault()?.ParameterType) // the benchmark that accepts an object[] as argument
                 {
                     return new ParameterInstances(
                         new[] { Create(parameterDefinitions, array[0], valuesInfo.source, sourceIndex, argumentIndex: 0, summaryStyle) });
@@ -87,7 +87,7 @@ namespace BenchmarkDotNet.Parameters
 
         public object Value { get; }
 
-        public string DisplayText => Value is Array array ? ArrayParam.GetDisplayString(array) : Value.ToString();
+        public string DisplayText => Value is Array array ? ArrayParam.GetDisplayString(array) : Value?.ToString() ?? ParameterInstance.NullParameterTextRepresentation;
 
         public string ToSourceCode()
         {
@@ -120,11 +120,11 @@ namespace BenchmarkDotNet.Parameters
 
         public object Value { get; }
 
-        public string DisplayText => Value is Array array ? ArrayParam.GetDisplayString(array) : Value.ToString();
+        public string DisplayText => Value is Array array ? ArrayParam.GetDisplayString(array) : Value?.ToString() ?? ParameterInstance.NullParameterTextRepresentation;
 
         public string ToSourceCode()
         {
-            string cast = $"({Value.GetType().GetCorrectCSharpTypeName()})";
+            string cast = Value == null ? string.Empty : $"({Value.GetType().GetCorrectCSharpTypeName()})";
 
             string instancePrefix = method.IsStatic ? source.DeclaringType.GetCorrectCSharpTypeName() : "instance";
 

--- a/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
+++ b/src/BenchmarkDotNet/Templates/WasmAotCsProj.txt
@@ -18,6 +18,7 @@
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
     <WasmNativeWorkload>false</WasmNativeWorkload>
     <UsingBrowserRuntimeWorkload>false</UsingBrowserRuntimeWorkload>
+    <EnableDefaultWasmAssembliesToBundle>false</EnableDefaultWasmAssembliesToBundle>
     $COPIEDSETTINGS$
   </PropertyGroup>
 
@@ -38,7 +39,7 @@
   </PropertyGroup>
   <Target Name="PrepareForWasmBuild" AfterTargets="Publish">
     <ItemGroup>
-      <WasmAssembliesToBundle Include="$(TargetDir)publish\*.dll" />
+      <WasmAssembliesToBundle Include="$(TargetDir)publish\*.dll" Exclude="$(TargetDir)publish\KernelTraceControl.dll" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CoreRt/CoreRtToolchain.cs
@@ -35,6 +35,8 @@ namespace BenchmarkDotNet.Toolchains.CoreRt
         /// compiled as net6.0, targets latest (6.0.0-*) CoreRT build from the new feed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json
         /// </summary>
         public static readonly IToolchain Core60 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net6.0").ToToolchain();
+        /// </summary>
+        public static readonly IToolchain Core70 = CreateBuilder().UseCoreRtNuGet().TargetFrameworkMoniker("net7.0").ToToolchain();
 
         internal CoreRtToolchain(string displayName,
             string coreRtVersion, string ilcPath, bool useCppCodeGenerator,

--- a/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
+++ b/src/BenchmarkDotNet/Toolchains/CsProj/CsProjCoreToolchain.cs
@@ -21,6 +21,7 @@ namespace BenchmarkDotNet.Toolchains.CsProj
         [PublicAPI] public static readonly IToolchain NetCoreApp31 = From(NetCoreAppSettings.NetCoreApp31);
         [PublicAPI] public static readonly IToolchain NetCoreApp50 = From(NetCoreAppSettings.NetCoreApp50);
         [PublicAPI] public static readonly IToolchain NetCoreApp60 = From(NetCoreAppSettings.NetCoreApp60);
+        [PublicAPI] public static readonly IToolchain NetCoreApp70 = From(NetCoreAppSettings.NetCoreApp70);
 
         private CsProjCoreToolchain(string name, IGenerator generator, IBuilder builder, IExecutor executor, string customDotNetCliPath)
             : base(name, generator, builder, executor)

--- a/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
+++ b/src/BenchmarkDotNet/Toolchains/DotNetCli/NetCoreAppSettings.cs
@@ -20,6 +20,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp31 = new NetCoreAppSettings("netcoreapp3.1", null, ".NET Core 3.1");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp50 = new NetCoreAppSettings("net5.0", null, ".NET 5.0");
         [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp60 = new NetCoreAppSettings("net6.0", null, ".NET 6.0");
+        [PublicAPI] public static readonly NetCoreAppSettings NetCoreApp70 = new NetCoreAppSettings("net7.0", null, ".NET 7.0");
 
         /// <summary>
         /// <param name="targetFrameworkMoniker">

--- a/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
+++ b/src/BenchmarkDotNet/Toolchains/ToolchainExtensions.cs
@@ -106,6 +106,8 @@ namespace BenchmarkDotNet.Toolchains
                     return CsProjCoreToolchain.NetCoreApp50;
                 case RuntimeMoniker.Net60:
                     return CsProjCoreToolchain.NetCoreApp60;
+                case RuntimeMoniker.Net70:
+                    return CsProjCoreToolchain.NetCoreApp70;
                 case RuntimeMoniker.CoreRt20:
                     return CoreRtToolchain.Core20;
                 case RuntimeMoniker.CoreRt21:
@@ -120,6 +122,8 @@ namespace BenchmarkDotNet.Toolchains
                     return CoreRtToolchain.Core50;
                 case RuntimeMoniker.CoreRt60:
                     return CoreRtToolchain.Core60;
+                case RuntimeMoniker.CoreRt70:
+                    return CoreRtToolchain.Core70;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimeMoniker), runtimeMoniker, "RuntimeMoniker not supported");
             }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -309,7 +309,8 @@ namespace BenchmarkDotNet.Tests
         [Theory]
         [InlineData("net50")]
         [InlineData("net60")]
-        public void Net50AndNet60MonikersAreRecognizedAsNetCoreMonikers(string tfm)
+        [InlineData("net70")]
+        public void NetMonikersAreRecognizedAsNetCoreMonikers(string tfm)
         {
             var config = ConfigParser.Parse(new[] { "-r", tfm }, new OutputLogger(Output)).config;
 

--- a/tests/BenchmarkDotNet.Tests/FolderNameTests.cs
+++ b/tests/BenchmarkDotNet.Tests/FolderNameTests.cs
@@ -12,6 +12,7 @@ namespace BenchmarkDotNet.Tests
         [InlineData(false, "false")]
         [InlineData(true, "true")]
         [InlineData("<MyString>", "_MyString_")]
+        [InlineData("TestCase:Arg", "TestCase_Arg")]
         [InlineData('a', "97")]
         [InlineData(0.42f, "0-42")]
         [InlineData(0.42d, "0-42")]

--- a/tests/BenchmarkDotNet.Tests/ParamsSourceTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ParamsSourceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Xunit;
+
+namespace BenchmarkDotNet.Tests
+{
+    public class ParamsSourceTests
+    {
+        // #1809
+        [Fact]
+        public void NullIsSupportedAsElementOfParamsSource()
+        {
+            BenchmarkConverter.TypeToBenchmarks(typeof(ParamsSourceWithNull));
+        }
+        
+        public class ParamsSourceWithNull
+        {
+            public static IEnumerable<object> Values()
+            {
+                yield return null;
+                yield return ValueTuple.Create(10);
+                yield return ValueTuple.Create(10, 20);
+                yield return (10, 20, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            }
+
+            [ParamsSource(nameof(Values))]
+            public object O { get; set; }
+
+            [Benchmark]
+            public object FooBar() => O;
+        }   
+    }
+}


### PR DESCRIPTION
- Also updated Microsoft.Win32.Registry to latest (5.0.0) since it is a direct dependency of the former.
- Fixes bugs in .Net Core >=3.1 builds in RuntimeInformation.GetAntivirusProducts() and GetVirtualMachineHypervisor() where the use of ManagementObjectSearcher throws a silently eaten exception.